### PR TITLE
Change menu selection variable to an enum

### DIFF
--- a/src/ui_elements/mainmenu.gd
+++ b/src/ui_elements/mainmenu.gd
@@ -1,4 +1,5 @@
 extends Control
+enum MenuType {MAIN, CREATE, JOIN, SERVER}
 
 onready var create_game_menu: MarginContainer = $CreateGameMenu
 onready var join_menu: MarginContainer = $JoinGameMenu
@@ -7,19 +8,19 @@ onready var main_menu: MarginContainer = $MainMenu
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	set_Visible_Menu("main_menu")
+	set_Visible_Menu(MenuType.MAIN)
 
 func _on_BackButton_pressed() -> void:
-	set_Visible_Menu("main_menu")
+	set_Visible_Menu(MenuType.MAIN)
 
 func _on_GameCreateButton_pressed() -> void:
-	set_Visible_Menu("create_game")
+	set_Visible_Menu(MenuType.CREATE)
 
 func _on_GameJoinButton_pressed() -> void:
-	set_Visible_Menu("join_game")
+	set_Visible_Menu(MenuType.JOIN)
 	
 func _on_ServerStartButton_pressed() -> void:
-	set_Visible_Menu("create_server")
+	set_Visible_Menu(MenuType.SERVER)
 
 func _on_AppQuitButton_pressed() -> void:
 	get_tree().quit()
@@ -27,10 +28,10 @@ func _on_AppQuitButton_pressed() -> void:
 func set_Visible_Menu(menu) -> void:
 	hide_Menus()
 	match menu:
-		"main_menu": main_menu.visible = true
-		"create_game": create_game_menu.visible = true
-		"join_game": join_menu.visible = true
-		"create_server": dedicated_menu.visible = true
+		MenuType.MAIN: main_menu.visible = true
+		MenuType.CREATE: create_game_menu.visible = true
+		MenuType.JOIN: join_menu.visible = true
+		MenuType.SERVER: dedicated_menu.visible = true
 
 func hide_Menus() -> void:
 	main_menu.visible = false

--- a/src/ui_elements/mainmenu.gd
+++ b/src/ui_elements/mainmenu.gd
@@ -1,4 +1,6 @@
 extends Control
+
+# --Variables--
 enum MenuType {MAIN, CREATE, JOIN, SERVER}
 
 onready var create_game_menu: MarginContainer = $CreateGameMenu
@@ -6,7 +8,7 @@ onready var join_menu: MarginContainer = $JoinGameMenu
 onready var dedicated_menu: MarginContainer = $DedicatedMenu
 onready var main_menu: MarginContainer = $MainMenu
 
-# Called when the node enters the scene tree for the first time.
+# --Interface--
 func _ready():
 	set_Visible_Menu(MenuType.MAIN)
 
@@ -39,6 +41,7 @@ func hide_Menus() -> void:
 	join_menu.visible = false
 	dedicated_menu.visible = false
 
+# --Backend--
 func _on_CreateGameStarter_pressed() -> void:
 	assert(false, "Game start not implemented yet")
 


### PR DESCRIPTION
Previously, the menu type was declared as a string. I have changed the menu type to be an enum, as it gives auto completion in the editor when setting the correct menu type.