### PR TITLE
Add gitignore and gitattributes files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png[[:space:]]*.ttf[[:space:]]*.svg filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+
+# Godot-specific ignores
+.import/
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/


### PR DESCRIPTION
We for some reason didn't have a .gitignore, so I copied over the one from OpenSuspect Legacy. Also I put in the gitattributes that wasn't commited, I think it is to do with the LFS.