### PR TITLE
No more issues with ghosts and items

### DIFF
--- a/src/resource_classes/character_resource.gd
+++ b/src/resource_classes/character_resource.gd
@@ -235,6 +235,8 @@ func getAbility(abilityName: String) -> Ability:
 	return null
 
 func canPickUpItem(itemRes) -> bool:
+	if not isAlive():
+		return false
 	if len(_items) > 0:
 		return false
 	return itemRes.canBePickedUp(self)


### PR DESCRIPTION
If character is not alive, it knows it can't pick up items, avoiding a crash.

Closes #98 